### PR TITLE
Introduce priority option when pushing jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,15 +167,21 @@ Valid options are:
 	* string parserable (ISO 8601 duration) by DateTimeInterval::__construct
 	* string parserable (relative parts) by DateTimeInterval::createFromDateString
 	* DateTimeInterval instance
+* priority: the lower the priority is, the sooner the job get popped from the queue (default to 1024)
 
 Examples:
 ```php
 	// scheduled for execution asap
     $queue->push($job);
+    
+    // will get executed before jobs that have higher priority
+    $queue->push($job, [
+        'priority' => 200,
+    ]);
 
 	// scheduled for execution 2015-01-01 00:00:00 (system timezone applies)
     $queue->push($job, array(
-        'scheduled' => 1420070400
+        'scheduled' => 1420070400,
     ));
 
     // scheduled for execution 2015-01-01 00:00:00 (system timezone applies)

--- a/data/DefaultQueue.php
+++ b/data/DefaultQueue.php
@@ -8,7 +8,14 @@ use DateTime;
 /**
  * DefaultQueue
  *
- * @ORM\Table(name="queue_default", options={"collate"="utf8_bin"}, indexes={@ORM\Index(name="pop", columns={"status","queue","scheduled"}),@ORM\Index(name="prune", columns={"status","queue","finished"})})
+ * @ORM\Table(
+ *     name="queue_default",
+ *     options={"collate"="utf8_bin"},
+ *     indexes={
+ *          @ORM\Index(name="pop", columns={"status", "queue", "scheduled", "priority}),
+ *          @ORM\Index(name="prune", columns={"status", "queue", "finished"})
+ *     }
+ * )
  * @ORM\Entity()
  */
 class DefaultQueue
@@ -72,6 +79,13 @@ class DefaultQueue
     private $finished;
 
     /**
+     * @var int
+     *
+     * @ORM\Column(name="int", type="integer", nullable=true)
+     */
+    private $priority;
+
+    /**
      * @var string
      *
      * @ORM\Column(name="message", type="text", nullable=true)
@@ -80,6 +94,7 @@ class DefaultQueue
 
     /**
      * @var string
+     *
      *
      * @ORM\Column(name="trace", type="text", nullable=true)
      */
@@ -317,5 +332,24 @@ class DefaultQueue
     public function getTrace()
     {
         return $this->trace;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /***
+     * @param int $priority
+     * @return $this
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
+
+        return $this;
     }
 }

--- a/data/queue_default.sql
+++ b/data/queue_default.sql
@@ -7,9 +7,10 @@ CREATE TABLE IF NOT EXISTS `queue_default` (
   `scheduled` datetime(6) NOT NULL,
   `executed` datetime(6) DEFAULT NULL,
   `finished` datetime(6) DEFAULT NULL,
+  `priority` int DEFAULT NOT NULL,
   `message` text,
   `trace` text,
   PRIMARY KEY (`id`),
-  KEY `pop` (`status`,`queue`,`scheduled`),
+  KEY `pop` (`status`,`queue`,`scheduled`,`priority`),
   KEY `prune` (`status`,`queue`,`finished`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;

--- a/tests/Asset/queue_default.sqlite
+++ b/tests/Asset/queue_default.sqlite
@@ -7,6 +7,7 @@ CREATE TABLE "queue_default" (
   "scheduled" datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   "executed" datetime NULL DEFAULT NULL,
   "finished" datetime NULL DEFAULT NULL,
+  "priority" int NOT NULL DEFAULT 1024,
   "message" text DEFAULT NULL,
   "trace" text,
   PRIMARY KEY ("id")

--- a/tests/Queue/DoctrineQueueTest.php
+++ b/tests/Queue/DoctrineQueueTest.php
@@ -79,6 +79,28 @@ class DoctrineQueueTest extends TestCase
         static::assertEquals($job, $poppedJob);
     }
 
+    public function testPopHighestPriority()
+    {
+        $jobA = new SimpleJob();
+        $this->queue->push($jobA, [
+            'priority' => 10,
+        ]);
+
+        $jobB = new SimpleJob();
+        $this->queue->push($jobB, [
+            'priority' => 5,
+        ]);
+
+        $jobC = new SimpleJob();
+        $this->queue->push($jobC, [
+            'priority' => 20,
+        ]);
+
+        static::assertEquals($jobB, $this->queue->pop());
+        static::assertEquals($jobA, $this->queue->pop());
+        static::assertEquals($jobC, $this->queue->pop());
+    }
+
     public function testJobCanBePushedMoreThenOnce()
     {
         $job = new SimpleJob();


### PR DESCRIPTION
This PR introduces a priority mode. Solving #122 I opened before.

The implemention will allow to set a priority when pushing a job on the queue. I.e.:

`$queue->push(new Job, ['priority' => 30]);`

The priority option does *not* work on release or bury. The Beanstalk adapter seems to do this; but I don't see any need for that at this point.

What we do need to worry about is how we are going to release this. It is a BC change in it's current form. So either we bump to 2.0 or we find a way to work around this in that it will not crash if the column does not exist. I think bumping the version is the right think to do. But would love your opinions.