### PR TITLE
Add missing default value for "priority" in queue_default.sql

### DIFF
--- a/data/queue_default.sql
+++ b/data/queue_default.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `queue_default` (
   `scheduled` datetime(6) NOT NULL,
   `executed` datetime(6) DEFAULT NULL,
   `finished` datetime(6) DEFAULT NULL,
-  `priority` int DEFAULT NOT NULL,
+  `priority` int DEFAULT 1 NOT NULL,
   `message` text,
   `trace` text,
   PRIMARY KEY (`id`),

--- a/data/queue_default.sql
+++ b/data/queue_default.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `queue_default` (
   `scheduled` datetime(6) NOT NULL,
   `executed` datetime(6) DEFAULT NULL,
   `finished` datetime(6) DEFAULT NULL,
-  `priority` int DEFAULT 1 NOT NULL,
+  `priority` int DEFAULT 1024 NOT NULL,
   `message` text,
   `trace` text,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
The queue_default.sql is missing the default value for the priority field. This leads to a broken SQL (at least in MariaDB 10.1.26).