### PR TITLE
Lock row when polling for it

### DIFF
--- a/src/Queue/DoctrineQueue.php
+++ b/src/Queue/DoctrineQueue.php
@@ -471,4 +471,3 @@ class DoctrineQueue extends AbstractQueue implements DoctrineQueueInterface
         }
     }
 }
-


### PR DESCRIPTION
Should solve issue #128. Curious to hear your opinion @basz. Or maybe someone that does have some experience with locking? 

The only way I see that working with Doctrine ORM is if we actually use a `Job` model. But that also means that we should make it configurable what model should be used. And that leads to a BC change in configuration; as at this moment we only know the table's name. So: both a BC and would take some time.

But I had the feeling at the very least the way to generate the SQL to lock should live in DBAL. So I reversed engineered how Doctrine ORM does it. Turns out it is pretty simple. Each platform describes the following: https://github.com/doctrine/dbal/blob/09e072dee1457bcdf3cae4be60b18854f8829992/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php#L1362-L1368. See:

![schermafdruk van 2017-10-20 14-16-01](https://user-images.githubusercontent.com/91910/31820355-3c09b7fe-b5a1-11e7-85b9-6d63235b58a2.png)

So to have proper locking evereywhere (when supported) we should:
1. Provide lock hint (we already do this)
2. Append the query with the part in `AbstractPlatform::getWriteLockSQL`

When applied it does resolve the crashes I reported earlier. And it does generate the expected SQL. Namely:

```sql
SELECT * FROM queue_default WHERE (status = ?) AND (queue = ?) AND (scheduled <= ?) ORDER BY priority ASC, scheduled ASC LIMIT 1 FOR UPDATE
```