### PR TITLE
Run clear EM before job starts. Fixes #117

### DIFF
--- a/src/Strategy/ClearObjectManagerStrategy.php
+++ b/src/Strategy/ClearObjectManagerStrategy.php
@@ -18,7 +18,7 @@ class ClearObjectManagerStrategy extends AbstractStrategy
         $this->listeners[] = $events->attach(
             AbstractWorkerEvent::EVENT_PROCESS_JOB,
             [$this, 'onClear'],
-            -1000
+            1000
         );
     }
 

--- a/tests/Strategy/ClearObjectManagerStrategyTest.php
+++ b/tests/Strategy/ClearObjectManagerStrategyTest.php
@@ -37,7 +37,7 @@ class ClearObjectManagerStrategyTest extends PHPUnit_Framework_TestCase
         $priority = 1;
 
         $evm->expects($this->at(0))->method('attach')
-            ->with(AbstractWorkerEvent::EVENT_PROCESS_JOB, [$this->listener, 'onClear'], -1000);
+            ->with(AbstractWorkerEvent::EVENT_PROCESS_JOB, [$this->listener, 'onClear'], 1000);
 
         $this->listener->attach($evm, $priority);
     }


### PR DESCRIPTION
Speaks for itself.

Does change behaviour; but I do not see this breaking something in any way. So can be just a minor release.

@basz Is there possibility of cutting a new release after this one? If not I'll just use `dev-master`. Just asking.