### PR TITLE
ups the minimum code sniffer, it causes false positives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "zendframework/zend-serializer": "^2.5",
         "zendframework/zend-mvc": "^2.5",
         "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "^2.1"
+        "squizlabs/php_codesniffer": "^2.7"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
on tests that run with `--prefer-lowest`