### PR TITLE
Doctrine module v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Created by Stefan Kleff
 
 Requirements
 ------------
-* [Zend Framework 2](https://github.com/zendframework/zf2)
+* [Zend-MVC](https://github.com/zendframework/zend-mvc)
 * [SlmQueue](https://github.com/juriansluiman/SlmQueue)
 * [Doctrine 2 ORM Module](https://github.com/doctrine/DoctrineORMModule)
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "zendframework/zend-servicemanager": "^2.7 || ^3.0",
         "zendframework/zend-stdlib": "^2.2 || ^3.0",
         "slm/queue": "^1.0",
-        "doctrine/doctrine-orm-module":  "~0.7 || ^1.0",
+        "doctrine/doctrine-orm-module":  "~0.7 || ^1.0 || ^2.1",
         "doctrine/dbal": "^2.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,11 @@
 {
     "name": "slm/queue-doctrine",
-    "description": "Zend Framework 2 module that integrates Doctrine as queuing system",
+    "description": "Zend Framework module that integrates Doctrine as queuing system",
     "license": "BSD-3-Clause",
     "type": "library",
     "keywords": [
         "zf2",
+        "zf3",
         "queue",
         "job",
         "doctrine",


### PR DESCRIPTION
DoctrineOrmModule just came out in version 2.1. Version 2.0 was just a pre-release not worth supporting.

As far as I can see there are no BC breaks in there that concerns SlmQueueDoctrine. 

I'll be testing it in our projects, but further tests may be necessary.