### PR TITLE
increase default size of data field

### DIFF
--- a/data/DefaultQueue.php
+++ b/data/DefaultQueue.php
@@ -39,7 +39,7 @@ class DefaultQueue
     /**
      * @var string
      *
-     * @ORM\Column(name="data", type="text", nullable=false)
+     * @ORM\Column(name="data", type="text", nullable=false, length=16777215)
      */
     private $data;
 

--- a/data/queue_default.sql
+++ b/data/queue_default.sql
@@ -1,7 +1,7 @@
-CREATE TABLE IF NOT EXISTS `queue_default` (
+CREATE TABLE IF NOT EXISTS `queue_defaults` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `queue` varchar(64) NOT NULL,
-  `data` text NOT NULL,
+  `data` mediumtext NOT NULL,
   `status` smallint(1) NOT NULL,
   `created` datetime(6) NOT NULL,
   `scheduled` datetime(6) NOT NULL,


### PR DESCRIPTION
data blob larger then 64Kb aren't possible. Doctrine silently fails. I think it is useful to use a medium text field by default.