### PR TITLE
Fix table name in create table SQL script

### DIFF
--- a/data/queue_default.sql
+++ b/data/queue_default.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS `queue_defaults` (
+CREATE TABLE IF NOT EXISTS `queue_default` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `queue` varchar(64) NOT NULL,
   `data` mediumtext NOT NULL,


### PR DESCRIPTION
As in DoctrineOptions.php#L25, the table name does not have the s in the and. It is just "queue_default", not "queue_defaults"